### PR TITLE
Changing all math to use BigDecimal for precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ functionality.
 Numbers
 -------
 
-All numbers are floating point.
+All numbers are BigDecimal ruby class numbers for precision.
 
-    1 => 1.0 
-    2.020 => 2.02 
+    1 => 1.0
+    2.020 => 2.02
     1.23E => 12300000000.0
 
 Arithmetic
@@ -37,7 +37,7 @@ Arithmetic is standard infix with nesting via parenthesis.
 Logical operations
 ------------------
 
-    2 < 1 ? 1 : 3 # Ternary 
+    2 < 1 ? 1 : 3 # Ternary
     (1 || 2) # 1.0
     2 or 3 # 2.0
     OR(1 > 2, 3 < 2, 8 == 8) # true
@@ -47,7 +47,7 @@ Variable assignment
 
 The assignment operator `:=` is borrowed from Pascal.  This decision was
 made for practical reason.  Since comparison operators are both `=` and
-`==` and the language is expression-based, `=` could not be chosen. 
+`==` and the language is expression-based, `=` could not be chosen.
 
 Variables come in a lot of different flavors.
 
@@ -98,7 +98,7 @@ Some of them are:
     # Random number generation
     RAND
 
-    # System level integration  
+    # System level integration
     SYSTEM
 
     # Boolean functions
@@ -120,7 +120,7 @@ Some of them are:
     REGEXP_MATCH, REGEXP_REPLACE
 
     # Debugging
-    P, PP, PUTS, 
+    P, PP, PUTS,
 
     # Other
     PLUS_ONE, MINUS_ONE, SQUARE, CUBE, FIB, FACTORIAL,
@@ -129,12 +129,12 @@ Some of them are:
 Loops
 -----
 
-There are no looping mechanisms to speak of, but recursion works (pretty) well.  
+There are no looping mechanisms to speak of, but recursion works (pretty) well.
 **Note:** *go too deep and you might blow the stack!*
 
-    DEFINE SAMPLE_LOOP(a) { 
-      PUTS(a) 
-      IF(a == 1, 1, SAMPLE_LOOP(a - 1)) 
+    DEFINE SAMPLE_LOOP(a) {
+      PUTS(a)
+      IF(a == 1, 1, SAMPLE_LOOP(a - 1))
     }
 
 There are a few examples of loops via recursion in `lib/stdlib.kalc`

--- a/lib/kalc.rb
+++ b/lib/kalc.rb
@@ -8,6 +8,7 @@ require 'kalc/transform'
 require 'kalc/environment'
 require 'kalc/interpreter'
 require 'kalc/repl'
+require 'bigdecimal'
 
 module Kalc
   class Runner

--- a/lib/kalc/ast.rb
+++ b/lib/kalc/ast.rb
@@ -77,15 +77,15 @@ module Kalc
       end
     end
 
-    class FloatingPointNumber
+    class BigDecimalNumber
       attr_reader :value
 
       def initialize(value)
-        @value = value
+        @value = BigDecimal.new(value.to_s)
       end
 
       def eval(context)
-        Float(@value)
+        BigDecimal.new(@value)
       end
     end
 

--- a/lib/kalc/interpreter.rb
+++ b/lib/kalc/interpreter.rb
@@ -139,7 +139,7 @@ module Kalc
         })
 
         env.add_function(:DOLLAR, lambda { |cxt, val, decimal_places|
-          "%.#{Integer(decimal_places.eval(cxt))}f" % Float(val.eval(cxt))
+          "%.#{Integer(decimal_places.eval(cxt))}f" % BigDecimal.new(val.eval(cxt))
         })
 
         env.add_function(:EXACT, lambda { |cxt, string1, string2|
@@ -152,7 +152,7 @@ module Kalc
         })
 
         env.add_function(:FIXED, lambda { |cxt, val, decimal_places, no_commas|
-          output = "%.#{Integer(decimal_places.eval(cxt))}f" % Float(val.eval(cxt))
+          output = "%.#{Integer(decimal_places.eval(cxt))}f" % BigDecimal.new(val.eval(cxt))
           output = output.to_s.reverse.scan(/(?:\d*\.)?\d{1,3}-?/).join(',').reverse if !no_commas.eval(cxt)
           output
         })

--- a/lib/kalc/transform.rb
+++ b/lib/kalc/transform.rb
@@ -54,7 +54,7 @@ module Kalc
     }
 
     rule(:number => simple(:number)) {
-      Ast::FloatingPointNumber.new(number)
+      Ast::BigDecimalNumber.new(number)
     }
 
     rule(:non_ops => subtree(:non_ops)) {

--- a/spec/grammar_spec.rb
+++ b/spec/grammar_spec.rb
@@ -9,7 +9,7 @@ describe Kalc::Grammar do
     end
   end
 
-  context 'floats' do
+  context 'decimal numbers' do
     1.upto(10) do |i|
       1.upto(10) do |n|
         it { grammar.should parse("#{i}.#{n}") }
@@ -27,7 +27,7 @@ describe Kalc::Grammar do
     end
   end
 
-  context 'basic float math' do
+  context 'basic decimal math' do
     1.upto(10) do |i|
       1.upto(10) do |n|
         it { grammar.should parse("#{i}.#{n} - #{i}.#{n}") }

--- a/spec/interpreter_spec.rb
+++ b/spec/interpreter_spec.rb
@@ -69,11 +69,12 @@ describe Kalc::Interpreter do
     it { evaluate('FALSE && TRUE').should == false }
   end
 
-  context 'Floating point number' do
+  context 'Decimal numbers' do
     it { evaluate('1.01').should == 1.01 }
     it { evaluate('1.01 + 0.02').should == 1.03 }
     it { evaluate('1.01 - 0.01').should == 1 }
     it { evaluate('1.1 + 1.1').should == 2.2 }
+    it { evaluate('1.2 - 1.0').should == 0.2 }
     it { evaluate('1.01 = 1.01').should == true }
     it { evaluate('1.01 = 1.02').should == false }
   end


### PR DESCRIPTION
Hey there, thanks for Kalc :)

I've been using it in a graphing project (https://ensight.exec.io) and we were getting floating point errors.  I forked your project and wrote a test for the error I was getting (line 77 of `spec/interpreter_spec.rb`)

The solution was migrating to Ruby BigDecimal class.  It handles everything you do in Floating Points but it gives you arbitrary precision decimal maths accuracy.

Hope you merge it :)
