### PR TITLE
Fix type round function

### DIFF
--- a/lib/kalc/interpreter.rb
+++ b/lib/kalc/interpreter.rb
@@ -83,7 +83,7 @@ module Kalc
         })
 
         env.add_function(:ROUND, lambda { |cxt, num, digits|
-          num.eval(cxt).round(digits.eval(cxt))
+          num.eval(cxt).round(digits.eval(cxt).to_i)
         })
 
         env.add_function(:SUM, lambda { |cxt, *args|

--- a/spec/interpreter_spec.rb
+++ b/spec/interpreter_spec.rb
@@ -120,6 +120,12 @@ describe Kalc::Interpreter do
     end
   end
 
+  context 'Round function' do
+    it { evaluate('ROUND(3.256,2)').should eq(3.26) }
+    it { evaluate('ROUND(3.2,2)').should eq(3.20) }
+    it { evaluate('ROUND(233.256,-2)').should eq(200) }
+  end
+
   private
   def evaluate(expression)
     g = @grammar.parse(expression)


### PR DESCRIPTION
After the change to return BigDecimals, it wasn't updated the digits to be an integer and the ruby round call was failing 